### PR TITLE
Added if/else statement for '0' operand

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ export const ACTIONS = {
 function reducer(state, { type, payload }) {
   switch (type) {
     case ACTIONS.ADD_DIGIT:
+      if (payload.digit === "0" && state.currentOperand === "0") return state
       return {
         ...state,
         currentOperand: `${state.currentOperand || ""}${payload.digit}`


### PR DESCRIPTION
The calculator no long allows more than one '0' to be added in the beginning without another actual number following.